### PR TITLE
Add dump on a periodic time

### DIFF
--- a/src/DumpOnException.CLI/Options.cs
+++ b/src/DumpOnException.CLI/Options.cs
@@ -32,6 +32,9 @@ namespace DumpOnException.CLI
         [Option('t', "threshold", Required = false, HelpText = "Sets the memory threshold in megabytes to create a dump.")]
         public int MemoryThreshold { get; set; } = 0;
 
+        [Option('p', "periodic-min", Required = false, HelpText = "Sets the periodic timeout in minutes to create a dump.")]
+        public int PeriodicDumpInMinutes { get; set; } = 0;
+        
         [Value(0, Hidden = true, Required = true, HelpText = "Command to be wrapped by the cli tool.")]
         public IEnumerable<string> Value { get; set; } = Enumerable.Empty<string>();
     }

--- a/src/DumpOnException.CLI/Program.cs
+++ b/src/DumpOnException.CLI/Program.cs
@@ -56,6 +56,7 @@ namespace DumpOnException.CLI
                 ["DOE_FILTER"] = options.Filter,
                 ["DOE_DIRECTORY"] = options.Directory,
                 ["DOE_MEMTHRESHOLD"] = options.MemoryThreshold.ToString(),
+                ["DOE_PERIODICMIN"] = options.PeriodicDumpInMinutes.ToString(),
                 ["DOE_ATTACH"] = options.AttachDebugger ? "1" : "0",
             };
             

--- a/src/DumpOnException.Dumpster/Listener.cs
+++ b/src/DumpOnException.Dumpster/Listener.cs
@@ -25,9 +25,19 @@ namespace DumpOnException.Dumpster
                 _currentProcess = Process.GetCurrentProcess();
                 _memoryThresholdThread = new Thread(() =>
                 {
+                    int currentMin = 0;
                     while (true)
                     {
                         Thread.Sleep(TimeSpan.FromMinutes(1));
+                        currentMin++;
+
+                        // If a periodic dump is set, and the threshold was reached
+                        if (Settings.PeriodicDumpInMinutes > 0 && currentMin >= Settings.PeriodicDumpInMinutes)
+                        {
+                            currentMin = 0;
+                            WriteDump("Periodic_Dump");
+                            continue;
+                        }
                         
                         _currentProcess.Refresh();
                         

--- a/src/DumpOnException.Dumpster/Settings.cs
+++ b/src/DumpOnException.Dumpster/Settings.cs
@@ -13,6 +13,7 @@ namespace DumpOnException.Dumpster
         public static Regex FilterRegex { get; }
         public static bool AttachDebugger { get; }
         public static int MemoryThreshold { get; }
+        public static int PeriodicDumpInMinutes { get; }
 
         static Settings()
         {
@@ -26,6 +27,12 @@ namespace DumpOnException.Dumpster
             if (int.TryParse(strMemoryThreshold, out int memThreshold))
             {
                 MemoryThreshold = memThreshold;
+            }
+
+            string strPeriodicDumpInMinutes = GetEnvironmentValue("DOE_PERIODICMIN", string.Empty);
+            if (int.TryParse(strPeriodicDumpInMinutes, out int intPeriodicDumpInMinutes))
+            {
+                PeriodicDumpInMinutes = intPeriodicDumpInMinutes;
             }
 
             static string GetEnvironmentValue(string name, string defaultValue)


### PR DESCRIPTION
This can help on those scenarios where we have a deadlock or we want to collect and compare between multiple dumps for the same processId.